### PR TITLE
Include very minimal jasmin_arc config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ See the `jasmin_arc` documentation on
 [readthedocs](http://jasmin-arc-py.readthedocs.io/en/latest/) for how to set up and install
 `jasmin_arc`.
 
-If not using the default settings (e.g. different location of private key, certificate,
-output filename etc) then create a JSON config file and put the path to it in `JASMIN_ARC_CONFIG`
-in `settings_local.py`.
+A minimal `jasmin_arc` config file is included at `arcproj/jasmin_arc_config.json`. To change other
+options (e.g. different location of private key, certificate, output filename etc), either edit
+this file or change the `JASMIN_ARC_CONFIG` setting in `settings_local.py` to point to a different
+config file.
 
 ## Set up database
 

--- a/arcproj/jasmin_arc_config.json
+++ b/arcproj/jasmin_arc_config.json
@@ -1,0 +1,3 @@
+{
+    "OUTPUT_FILE": "outputs.zip"
+}

--- a/arcproj/settings_local.py.tmpl
+++ b/arcproj/settings_local.py.tmpl
@@ -26,4 +26,4 @@ DATABASES = {
 }
 
 # Path to JSON config file for jasmin_arc, or None to use default config
-JASMIN_ARC_CONFIG = None
+JASMIN_ARC_CONFIG = os.path.join(BASE_DIR, 'arcproj/jasmin_arc_config.json')


### PR DESCRIPTION
The default output filename did not match the output produced by
the diff_era_nc.py script, so needed to add a config to change the `OUTPUT_FILE` option.